### PR TITLE
Add pefile as a setup.py dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,8 @@ from setuptools import setup
 requirements = [
     'pefile',
     # Wish I could just add the Vivisect zipball here but that doesn't work,
-    # so you still must either `pip -r requirements.txt` or `pip install
-    # https://github.com/williballenthin/vivisect/zipball/master`
+    # so you still must either `pip install -r requirements.txt` or `pip
+    # install https://github.com/williballenthin/vivisect/zipball/master`
 ]
 
 # Utility function to read the README file.

--- a/setup.py
+++ b/setup.py
@@ -4,11 +4,17 @@
 import os
 from setuptools import setup
 
+requirements = [
+    'pefile',
+    # Wish I could just add the Vivisect zipball here but that doesn't work,
+    # so you still must either `pip -r requirements.txt` or `pip install
+    # https://github.com/williballenthin/vivisect/zipball/master`
+]
+
 # Utility function to read the README file.
 # Used for the long_description.  It's nice, because now 1) we have a top level
 # README file and 2) it's easier to type in the README file than to put a raw
 # string in below ...
-
 
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()


### PR DESCRIPTION
Alas, still can't do this for Vivisect, so the `pip install -r requirements.txt` or `pip install <vivisect_zipball_location>` step is still needed.